### PR TITLE
Ansible switches auto deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.env
+.pytest_cache
+__pycache__
+Pipfile
+Pipfile.lock
+.coverage

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi9/python-311:latest
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+RUN ansible-galaxy collection install dellemc.os9 && \
+	ansible-galaxy collection install amazon.aws
+COPY . ./
+
+CMD [ "gunicorn", "-b", "0.0.0.0:8000", "app:app"]

--- a/app.py
+++ b/app.py
@@ -1,0 +1,6 @@
+import notifier
+
+app = notifier.create_app()
+
+if __name__ == "__main__":
+    app.run()

--- a/github.py
+++ b/github.py
@@ -1,0 +1,52 @@
+import flask
+import hmac
+
+SIGNATURE_HEADER = "X-Hub-Signature-256"
+
+
+class WebhookSignatureError(Exception):
+    pass
+
+
+class GithubSignatureVerifier:
+    """Implement webhook request validation as described in [1].
+
+    [1]: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+    """
+
+    def __init__(self, secret: str):
+        self.secret = secret.encode()
+
+    def verify_webhook_signature(self, request: flask.Request) -> bool:
+        try:
+            signature_header = request.headers[SIGNATURE_HEADER]
+            signature_sha_name, request_signature = signature_header.split("=", 1)
+        except KeyError:
+            raise WebhookSignatureError("missing signature header")
+        except ValueError:
+            raise WebhookSignatureError("unable to parse signature header")
+
+        if signature_sha_name != "sha256":
+            raise WebhookSignatureError(
+                f"unknown signature type ({signature_sha_name})"
+            )
+
+        local_signature = hmac.HMAC(
+            key=self.secret,
+            msg=request.data,
+            digestmod="sha256",
+        )
+
+        if not hmac.compare_digest(request_signature, local_signature.hexdigest()):
+            raise WebhookSignatureError(
+                f"bad signature: request {request_signature}, local {local_signature.hexdigest()}",
+            )
+
+        return True
+
+
+class GithubNullVerifier:
+    """A null verifier that is always successful."""
+
+    def verify_webhook_signature(self, request: flask.Request) -> bool:
+        return True

--- a/notifier.py
+++ b/notifier.py
@@ -1,0 +1,231 @@
+from flask import Flask, request, current_app, abort
+import git
+import ansible_runner
+import os
+import requests
+import json
+import logging
+import slack
+import github
+
+os.environ['ANSIBLE_NOCOLOR'] = "True"
+
+class CONFIG_DEFAULTS:
+    COLOR_SUCCESS = "#05eb2f"
+    COLOR_FAILURE = "#f00216"
+    VERIFY_WEBHOOK_SIGNATURE = False
+
+class ConfigurationError(Exception):
+    pass
+
+
+def require_config(app, name):
+    if name not in app.config:
+        raise ConfigurationError(f"missing {name}")
+
+
+
+def updateRepo(repoDir, repoURL, commitID):
+    """Clone or update the local git repository"""
+    if os.path.isdir(
+        repoDir
+    ):  # If the clone of the repo exists pull updates, if not clone it
+        repo = git.Repo(repoDir)
+        o = repo.remotes.origin
+        repo.git.checkout("main")
+        o.pull()
+        repo.git.checkout(commitID)
+        current_app.logger.info("pulled changes for %s", repoURL)
+    else:
+        repo = git.Repo.clone_from(repoURL, repoDir, no_checkout=True)
+        repo.git.checkout(commitID)
+        current_app.logger.info("clone %s", repoURL)
+
+
+
+def fileChanges(
+    commits,
+):
+    """Returns bool for if vlan file changes and list of individual switch changes"""
+    vlanChange = False  # Vlan Flag
+    switchChanges = []  # List of modified switches
+
+    for commit in commits:  # Look at each commit in push to main branch
+        for path in commit["modified"]:  # Look at the files modified in each commit
+            if path == "group_vars/all/vlans.yaml":
+                vlanChange = True
+
+            elif path.startswith("host_vars") and path.endswith("interfaces.yaml"):
+                switchChanges.append(path.split("/")[1])
+
+        current_app.logger.info(
+            "Vlan change: %s Switch changes: %s", vlanChange, switchChanges
+        )
+
+        for path in commit.get("added", []):
+            switchChanges.append(path.split("/")[1])
+
+    return (vlanChange, switchChanges)
+
+
+def runAnsible(repoDir, vlanFlag, switchList):
+    """Run the deployment playbook"""
+    playbook = current_app.config.get("AUTODEPLOY_PLAYBOOK", "deploy.yaml")
+
+    if (
+        vlanFlag
+    ):  # If the vlanFlag is true run playbook on all switches else only on switches with changes
+        res = ansible_runner.run(
+            private_data_dir=repoDir,
+            playbook=playbook,
+        )
+        current_app.logger.info("Vlan change, all switches update.")
+
+    else:
+        strSwitchList = ",".join(
+            str(switch) for switch in switchList # map(str, switchList)
+        )  # Convert the list to string, items seperated by commas
+        res = ansible_runner.run(
+            private_data_dir=repoDir,
+            playbook=playbook,
+            limit=strSwitchList,  # equivalent to --limit
+        )
+        current_app.logger.info("Individual switch change: %s", strSwitchList)
+    return (res.status, res.stdout)
+
+
+def sendAlert(vlanFlag, switchList, status, stdoutFile):
+    """Send notification to slack channel"""
+    strSwitchList = ",".join(
+        str(switch) for switch in switchList # map(str, switchList)
+    )  # Convert the list to string, items seperated by commas
+
+    if (
+        vlanFlag
+    ):  # Create the messages for the alerts, different depending on what switches were changed
+        # LKS: Here (and elsewhere) we should probably look into using
+        # python f-strings rather than string concatenation.
+        change_message = "All switches were changed."
+    else:
+        change_message = f"Switches: {strSwitchList}"
+
+    stdout = stdoutFile.read()
+
+    if len(stdout) > 2990:
+        stdout = stdout[-2990:]
+    
+    if status == "failed":
+        header = "Switch Notification :large_red_square:"
+    else:
+        header = "Switch Notification :large_green_square:"
+
+    message = slack.SlackMessage(
+        blocks=[
+            slack.SlackHeaderBlock(
+                text=slack.SlackText(text=f"{header}")
+            ),
+            slack.SlackSectionBlock(
+                text=slack.SlackMarkdown(
+                    text=f"Changes detected in switch configuration.\nEffected switches: {change_message}\nStatus: {status.upper()}"
+                )
+            ),
+        ],
+    )
+
+    message.attachments = [
+        slack.SlackAttachment(
+            blocks=[
+                slack.SlackSectionBlock(
+                    text=slack.SlackMarkdown(text=f"```\n{stdout}\n```")
+                ),
+            ]
+        ),
+    ]
+
+    if current_app.notifier:
+            try:
+                current_app.notifier.notify(message)
+                current_app.logger.info("Slack notification sent")
+            except slack.SlackException as err:
+                current_app.logger.error("slack notification failed: %s", err)
+    return "success", 200
+
+
+
+def create_app(config_from_env=True, config=None):
+    """Create and configure flask application"""
+    app = Flask(__name__)
+
+    # Configure application:
+    #   Defaults ->
+    #     Environment ->
+    #       Explicit config
+    app.config.from_object(CONFIG_DEFAULTS)
+    if config_from_env:
+        app.config.from_prefixed_env()
+    app.config.from_object(config)
+
+    require_config(app, "SLACK_WEBHOOK_URL")
+    app.notifier = slack.SlackNotifier(app.config["SLACK_WEBHOOK_URL"])
+
+    if app.config.get("VERIFY_WEBHOOK_SIGNATURE", True):
+        require_config(app, "GITHUB_WEBHOOK_SECRET")
+        app.verifier = github.GithubSignatureVerifier(
+            app.config["GITHUB_WEBHOOK_SECRET"]
+        )
+    else:
+        app.verifier = github.GithubNullVerifier()
+
+    @app.route("/healthz", methods=["GET"])
+    def healthz():
+        return "OK"
+
+    @app.route("/webhook", methods=["POST"])
+    def handle_push_notification():
+        try:
+            current_app.verifier.verify_webhook_signature(request)
+        except github.WebhookSignatureError as err:
+            current_app.logger.error(f"invalid signature: {err}")
+            abort(400, "Bad signature")
+
+        if "X-GitHub-Event" not in request.headers:
+            abort(400, "Missing x-github-event header")
+
+        if request.headers["X-GitHub-Event"] == "ping":
+            return {"status": "ping successful"}
+
+        if request.headers["X-GitHub-Event"] != "push":
+            abort(400, "Unsupported event")
+
+        current_app.logger.info("received valid notification from github")
+
+        #Read in config from .env file
+        repoURL = current_app.config["AUTODEPLOY_REPOURL"]
+        repoDir = current_app.config.get(
+            "AUTODEPLOY_REPODIR", os.path.basename(repoURL)
+        )
+        webhookURL = current_app.config["SLACK_WEBHOOK_URL"]
+
+        current_app.logger.info("received webhook")
+
+        vlanFlag, switchList = fileChanges(request.json["commits"])
+        if vlanFlag or switchList:
+            current_app.logger.info("changes detected")
+
+            commitID = request.json["head_commit"]["id"]
+
+            updateRepo(repoDir, repoURL, commitID)
+            status, stdoutFile = runAnsible(repoDir, vlanFlag, switchList)
+
+            current_app.logger.info("sending notification to %s", webhookURL)
+
+            sendAlert(vlanFlag, switchList, status, stdoutFile)
+
+        return "success", 200
+
+    @app.before_request
+    def configure_logging():
+        logging.basicConfig(level=current_app.config.get("LOGLEVEL", "INFO"))
+
+    return app
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+flask
+gunicorn
+ansible
+ansible_runner
+ansible-pylibssh
+jsonschema
+GitPython
+requests
+python-dotenv

--- a/slack.py
+++ b/slack.py
@@ -1,0 +1,137 @@
+'''Code for generating slack messages using the block api [1].
+
+[1]: https://api.slack.com/reference/block-kit/blocks
+'''
+
+from dataclasses import dataclass, asdict
+import requests
+import json
+import enum
+
+
+class SlackException(Exception):
+    pass
+
+
+class SlackTextType(enum.StrEnum):
+    """Valid types for text blocks"""
+
+    PLAIN_TEXT = "plain_text"
+    MARKDOWN = "mrkdwn"
+
+
+class SlackBlockType(enum.StrEnum):
+    """Valid block types"""
+
+    SECTION = "section"
+    HEADER = "header"
+    DIVIDER = "divider"
+
+
+class jsonObject:
+    @classmethod
+    def remove_none(cls, value):
+        """
+        Recursively remove all None values from dictionaries and lists, and returns
+        the result as a new dictionary or list.
+
+        via https://stackoverflow.com/a/60124334/147356
+        """
+        if isinstance(value, list):
+            return [cls.remove_none(x) for x in value if x is not None]
+        elif isinstance(value, dict):
+            return {
+                key: cls.remove_none(val)
+                for key, val in value.items()
+                if val is not None
+            }
+        else:
+            return value
+
+    def asdict(self, ignore_none=False):
+        return self.remove_none(asdict(self))
+
+    def asjson(self, ignore_none=False, **kwargs):
+        return json.dumps(self.asdict(ignore_none=ignore_none), **kwargs)
+
+
+@dataclass
+class SlackMarkdown(jsonObject):
+    text: str
+    type: SlackTextType = SlackTextType.MARKDOWN
+
+
+@dataclass
+class SlackText(jsonObject):
+    text: str
+    type: SlackTextType = SlackTextType.PLAIN_TEXT
+
+
+class SlackBlock(jsonObject):
+    pass
+
+
+class SlackField(jsonObject):
+    pass
+
+
+@dataclass
+class SlackMarkdownField(SlackField):
+    text: str
+    emoji: bool = False
+    type: SlackTextType = SlackTextType.MARKDOWN
+
+
+@dataclass
+class SlackTextField(SlackField):
+    text: str
+    emoji: bool = False
+    type: SlackTextType = SlackTextType.PLAIN_TEXT
+
+
+@dataclass
+class SlackSectionBlock(SlackBlock):
+    text: SlackMarkdown | SlackText | None = None
+    fields: list[SlackField] | None = None
+    type: SlackBlockType = SlackBlockType.SECTION
+
+
+@dataclass
+class SlackHeaderBlock(SlackBlock):
+    text: SlackText
+    type: SlackBlockType = SlackBlockType.HEADER
+
+
+@dataclass
+class SlackDividerBlock(SlackBlock):
+    type: SlackBlockType = SlackBlockType.DIVIDER
+
+
+@dataclass
+class SlackAttachment(jsonObject):
+    blocks: list[SlackBlock] | None = None
+    color: str | None = None
+    text: str | None = None
+
+
+@dataclass
+class SlackMessage(jsonObject):
+    text: str | None = None
+    attachments: list[SlackAttachment] | None = None
+    blocks: list[SlackBlock] | None = None
+
+
+@dataclass
+class SlackNotifier(jsonObject):
+    notify_url: str
+
+    def notify(self, message: SlackMessage):
+        """Send a notification via a slack webhook url"""
+
+        content = message.asdict(ignore_none=True)
+
+        res = requests.post(self.notify_url, json=content)
+        try:
+            res.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise SlackException(res.text)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-httpserver
+pytest-cov

--- a/test_github.py
+++ b/test_github.py
@@ -1,0 +1,56 @@
+import pytest
+import github
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Request:
+    headers: dict[str, str] = field(default_factory=dict)
+    data: bytes = b""
+
+
+@pytest.fixture
+def verifier():
+    return github.GithubSignatureVerifier("secret")
+
+
+def test_missing_header(verifier):
+    request = Request()
+    with pytest.raises(github.WebhookSignatureError) as err:
+        verifier.verify_webhook_signature(request)
+
+    assert str(err.value) == "missing signature header"
+
+
+def test_unknown_sha(verifier):
+    request = Request(headers={github.SIGNATURE_HEADER: "test=test"})
+    with pytest.raises(github.WebhookSignatureError) as err:
+        verifier.verify_webhook_signature(request)
+
+    assert str(err.value) == "unknown signature type (test)"
+
+
+def test_invalid_header(verifier):
+    request = Request(headers={github.SIGNATURE_HEADER: "test"})
+    with pytest.raises(github.WebhookSignatureError) as err:
+        verifier.verify_webhook_signature(request)
+
+    assert str(err.value) == "unable to parse signature header"
+
+
+def test_bad_signature(verifier):
+    request = Request(headers={github.SIGNATURE_HEADER: "sha256=test"})
+    with pytest.raises(github.WebhookSignatureError) as err:
+        verifier.verify_webhook_signature(request)
+
+    assert str(err.value).startswith("bad signature")
+
+
+def test_good_signature(verifier):
+    request = Request(
+        headers={
+            github.SIGNATURE_HEADER: "sha256=f9e66e179b6747ae54108f82f8ade8b3c25d76fd30afde6c395822c530196169"
+        }
+    )
+    verifier.verify_webhook_signature(request)

--- a/test_notifier.py
+++ b/test_notifier.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch, Mock
+import pytest
+import notifier
+from pathlib import Path
+
+notify_with_vlan_change = {
+    "commits": [{"modified": ["group_vars/all/vlans.yaml"]}],
+    "head_commit": {"id": "b7b84665d4a848dfd57980348fc04c0392a63bb7"},
+}
+
+notify_with_switch_change = {
+    "commits": [{"modified": ["host_vars/switch1/interfaces.yaml"]}],
+    "head_commit": {"id": "b7b84665d4a848dfd57980348fc04c0392a63bb7"},
+}
+
+
+@pytest.fixture()
+def testapp(httpserver):
+    class config:
+        AUTODEPLOY_REPOURL = "unused-in-testing"
+        SLACK_WEBHOOK_URL = httpserver.url_for("/notify")
+        VERIFY_WEBHOOK_SIGNATURE = False
+
+    tester = notifier.create_app(config_from_env=False, config=config)
+
+    yield tester
+
+
+@pytest.fixture()
+def client(testapp):
+    with patch("notifier.updateRepo"):
+        yield testapp.test_client()
+
+
+# In the following tests we don't actually run ansible, nor do we
+# attempt to clone a remote repository. We prevent the latter by
+# simplying mocking out the updateRepo method (see the `client`
+# fixture, above). For Ansible, we create a mock for the
+# `ansible_runner.run` method, and then set explicit return values on
+# that mock to get the behavior we want from the code under test.
+
+
+@pytest.mark.parametrize(
+    "payload,expected_text",
+    (
+        (notify_with_vlan_change, "successful"),
+        (notify_with_vlan_change, "failed"),
+        (notify_with_switch_change, "successful"),
+        (notify_with_switch_change, "failed"),
+    ),
+)
+@patch("notifier.ansible_runner.run")
+def test_vlan_change_deploy_success(
+    fake_run, payload, expected_text, tmp_path, httpserver, testapp, client
+):
+    def handler(req):
+        assert f"status: {expected_text}" in req.data.decode().lower()
+
+    stdout_path = tmp_path / "stdout.txt"
+    with stdout_path.open("w") as fd:
+        fd.write("This is a test")
+    with stdout_path.open() as fd:
+        fake_run.return_value = Mock(status=expected_text, stdout=fd)
+
+        httpserver.expect_request("/notify").respond_with_handler(handler)
+        res = client.post(
+            "/webhook",
+            json=payload,
+            headers={"x-github-event": "push"},
+        )
+        assert res.status_code == 200
+        httpserver.check_assertions()

--- a/test_slack.py
+++ b/test_slack.py
@@ -1,0 +1,11 @@
+import pytest
+import slack
+
+
+@pytest.mark.parametrize(
+    "block_class,block_type",
+    [(slack.SlackMarkdown, "mrkdwn"), (slack.SlackText, "plain_text")],
+)
+def test_text_blocks(block_class, block_type):
+    block = block_class(text="test")
+    assert block.asdict() == {"type": block_type, "text": "test"}


### PR DESCRIPTION
This PR expands upon the original PR that include the code for implementing automatic running of an anisble playbook to deploy manifests to switches. This new PR includes the code change requests including adding testing, making the code more clear and concise, including logging, pulling configuration from an .env file and a few other minor changes. This PR also implements a working Container file improving upon the one in the initial PR by storing the requirements in a separate requirements.txt file. Finally the new code takes advantage of two files written by @larsks  github.py and slack.py, the latter being used to generate messages to send to slack without having to create the JSON payload yourself, and the former implementing verification to ensure that requests are coming from Github.